### PR TITLE
Remove cuopt from nightly pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -30,7 +30,6 @@ jobs:
         rapidsai/cugraph-ops
         rapidsai/cuml
         rapidsai/cumlprims_mg
-        rapidsai/cuopt
         rapidsai/cuspatial
         rapidsai/cuxfilter
         rapidsai/dask-cuda
@@ -182,42 +181,6 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
-  cuopt-build:
-    needs: [get-run-info, rmm-build, raft-build, cudf-build]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: rapidsai
-          repo: cuopt
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: build.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuopt) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
-  cuopt-tests:
-    needs: [get-run-info, cuopt-build]
-    if: ${{ needs.cuopt-build.result == 'success' && !cancelled() && inputs.run_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: rapidsai
-          repo: cuopt
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuopt) }}
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true


### PR DESCRIPTION
`cuopt` is moving to a different release cycle, so it can removed from the RAPIDS nightly pipeline.

A future `cuopt`-specific nightly pipeline will be setup separately (likely in that repo).