### PR TITLE
Adds cudf-pandas-integration to nightly-pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -26,6 +26,7 @@ jobs:
       repos: >-
         rapidsai/cucim
         rapidsai/cudf
+        rapidsai/cudf-pandas-integration
         rapidsai/cugraph
         rapidsai/cugraph-ops
         rapidsai/cuml
@@ -42,7 +43,6 @@ jobs:
         rapidsai/ucxx
         rapidsai/ucx-py
         rapidsai/wholegraph
-        rapidsai/cudf-pandas-integration
   rmm-build:
     needs: [get-run-info]
     if: ${{ !cancelled() }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -42,6 +42,7 @@ jobs:
         rapidsai/ucxx
         rapidsai/ucx-py
         rapidsai/wholegraph
+        rapidsai/xdf-integration
   rmm-build:
     needs: [get-run-info]
     if: ${{ !cancelled() }}
@@ -182,6 +183,24 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  cudf-pandas-integration-tests:
+    needs: [get-run-info, cudf-build]
+    if: ${{ needs.cudf-build.result == 'success' && !cancelled() && inputs.run_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: rapidsai
+          repo: xdf-integration
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: nightly.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf-pandas-integration) }}
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -42,7 +42,7 @@ jobs:
         rapidsai/ucxx
         rapidsai/ucx-py
         rapidsai/wholegraph
-        rapidsai/xdf-integration
+        rapidsai/cudf-pandas-integration
   rmm-build:
     needs: [get-run-info]
     if: ${{ !cancelled() }}
@@ -194,7 +194,7 @@ jobs:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: rapidsai
-          repo: xdf-integration
+          repo: cudf-pandas-integration
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: nightly.yaml


### PR DESCRIPTION
This PR adds `cudf-pandas-integration` nightly tests to rapids nightly-pipeline. The tests are triggered after cudf nightly is built.

closes rapidsai/cudf-pandas-integration#67