### PR TITLE
Temporarily disable 24.02

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -13,8 +13,8 @@ jobs:
         include:
           - rapids_version: "23.12"
             run_tests: true
-          - rapids_version: "24.02"
-            run_tests: false
+          # - rapids_version: "24.02"
+          #  run_tests: false
     steps:
       - uses: actions/checkout@v3
       - name: Trigger Pipeline


### PR DESCRIPTION
We need to run some `24.02` builds w/ test manually for a couple days, so I'm disabling the nightly run so that the test run is not inadvertently cancelled.

This PR will be reverted.