### PR TITLE
Disable 23.12 nightlies

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - rapids_version: "23.12"
-            run_tests: true
           - rapids_version: "24.02"
-            run_tests: false
+            run_tests: true
     steps:
       - uses: actions/checkout@v3
       - name: Trigger Pipeline


### PR DESCRIPTION
Now that the v23.12 release is complete, rollover the nightlies to 24.02 with testing.