### PR TITLE
Switch nightlies to 24.04 only

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - rapids_version: "24.02"
-            run_tests: true
           - rapids_version: "24.04"
-            run_tests: false
+            run_tests: true
     steps:
       - uses: actions/checkout@v3
       - name: Trigger Pipeline


### PR DESCRIPTION
`24.02` release is complete, so that can be dropped and `24.04` tests added to nightlies.