### PR TITLE
Add `retry` & `sleep` to clean up script

### DIFF
--- a/ci/cleanup_images.sh
+++ b/ci/cleanup_images.sh
@@ -10,6 +10,7 @@ delete_image() {
     local tag=$3
 
     curl --silent --fail-with-body -X DELETE \
+        --retry 5 --retry-all-errors \
         -H "Accept: application/json" \
         -H "Authorization: JWT $HUB_TOKEN" \
         "https://hub.docker.com/v2/repositories/$org/$repo/tags/$tag/"
@@ -23,6 +24,7 @@ fetch_tags() {
     local page=$3
 
     curl --silent -L --fail-with-body \
+        --retry 5 --retry-all-errors \
         -H "Accept: application/json" \
         -H "Authorization: JWT $HUB_TOKEN" \
         "https://hub.docker.com/v2/namespaces/$org/repositories/$repo/tags?page=$page&page_size=100"
@@ -43,6 +45,7 @@ echo "$tags_json" | jq -c '.results[]' | while read -r tag_info; do
 
         if [ "$age_in_days" -gt 30 ]; then
             delete_image "$org" "$repo" "$tag_name"
+            sleep 1s
         else
             echo "${tag_name} is less than 30 days old. Not deleting."
         fi


### PR DESCRIPTION
This PR adds a `--retry` flag to the `curl` commands for the nightly Docker clean up script.

It also adds a `sleep` after each image deletion.

These additions should help reduce the amount of job failures that result from DockerHub 500 errors, like the ones shown below:

- https://github.com/rapidsai/workflows/actions/runs/8413158981/job/23034970956#step:3:1610
- https://github.com/rapidsai/workflows/actions/runs/8405457190/job/23018200736#step:3:1738