### PR TITLE
Use CI codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 #build/ops code owners
-* @rapidsai/ops-codeowners
+* @rapidsai/ci-codeowners


### PR DESCRIPTION
This PR overhauls how `ops-codeowners` reviews are handled.

`ops-codeowners` is replaced by `ci-codeowners` & `packaging-codeowners`. The coverage of files is expanded as well.

Additionally, the process will change: reviews will be assigned to a member of the teams instead of a manual request to `ops-codeowners`.
