### PR TITLE
Remove standalone cudf-pandas integration tests job

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -26,7 +26,6 @@ jobs:
       repos: >-
         rapidsai/cucim
         rapidsai/cudf
-        rapidsai/cudf-pandas-integration
         rapidsai/cugraph
         rapidsai/cugraph-ops
         rapidsai/cuml
@@ -183,24 +182,6 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
-  cudf-pandas-integration-tests:
-    needs: [get-run-info, cudf-build]
-    if: ${{ needs.cudf-build.result == 'success' && !cancelled() && inputs.run_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
-        with:
-          owner: rapidsai
-          repo: cudf-pandas-integration
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: nightly.yaml
-          ref: main
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cudf-pandas-integration) }}
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true


### PR DESCRIPTION
https://github.com/rapidsai/cudf-pandas-integration/ has been archived and the tests were added into the cudf repo in https://github.com/rapidsai/cudf/pull/16645.