### PR TITLE
Roll over to 24.12

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - rapids_version: "24.10"
-            run_tests: true
           - rapids_version: "24.12"
-            run_tests: false
+            run_tests: true
     steps:
       - uses: actions/checkout@v3
       - name: Trigger Pipeline


### PR DESCRIPTION
The `24.10` release is almost complete, so remove it from nightlies and enable tests for `24.12`.