### PR TITLE
add nx-cugraph to nightly pipeline

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -37,6 +37,7 @@ jobs:
         rapidsai/docker
         rapidsai/integration
         rapidsai/kvikio
+        rapidsai/nx-cugraph
         rapidsai/rapids-cmake
         rapidsai/raft
         rapidsai/rmm
@@ -326,6 +327,42 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  nx-cugraph-build:
+    needs: [get-run-info, cugraph-build]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rapidsai/trigger-workflow-and-wait@v1
+        with:
+          owner: rapidsai
+          repo: nx-cugraph
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.nx-cugraph) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  nx-cugraph-tests:
+    needs: [get-run-info, cudf-build, cugraph-build]
+    if: ${{ needs.cugraph-build.result == 'success' && !cancelled() && inputs.run_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rapidsai/trigger-workflow-and-wait@v1
+        with:
+          owner: rapidsai
+          repo: nx-cugraph
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: test.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.nx-cugraph) }}
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
@@ -648,6 +685,7 @@ jobs:
       - cuxfilter-build
       - dask-cuda-build
       - kvikio-build
+      - nx-cugraph-build
       - raft-build
       - rapids-cmake-build
       - rmm-build
@@ -683,6 +721,7 @@ jobs:
       - cuxfilter-build
       - dask-cuda-build
       - kvikio-build
+      - nx-cugraph-build
       - raft-build
       - rapids-cmake-build
       - rmm-build


### PR DESCRIPTION
In the 24.12 release, `nx-cugraph` moved out of https://github.com/rapidsai/cugraph and into its own repo: https://github.com/rapidsai/nx-cugraph

This proposes triggering nightly builds and tests for that repo.