### PR TITLE
Add missing cuvs dependency to cuml

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -259,7 +259,7 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
   cuml-build:
-    needs: [get-run-info, cudf-build, raft-build, cumlprims_mg-build]
+    needs: [get-run-info, cudf-build, raft-build, cuvs-build, cumlprims_mg-build]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
cuml now requires cuvs in order to build so the dependency tree needs to be updated accordingly in the nightly workflow.