### PR TITLE
enable cugraph-docs nightly builds

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -27,6 +27,7 @@ jobs:
         rapidsai/cucim
         rapidsai/cudf
         rapidsai/cugraph
+        rapidsai/cugraph-docs
         rapidsai/cugraph-gnn
         rapidsai/cugraph-ops
         rapidsai/cuml
@@ -633,6 +634,24 @@ jobs:
           ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cumlprims_mg) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  cugraph-docs-build:
+    needs: [get-run-info, cugraph-build, cugraph-gnn-build, cugraph-ops-build, nx-cugraph-build]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rapidsai/trigger-workflow-and-wait@v1
+        with:
+          owner: rapidsai
+          repo: cugraph-docs
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cugraph-docs) }}
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true


### PR DESCRIPTION
Starting with the 25.02 release, docs building for all of the cuGraph projects (e.g. `cugraph`, `nx-cugraph`, `wholegraph`, etc.) has moved to a single repo: https://github.com/rapidsai/cugraph-docs.

Now that https://github.com/rapidsai/cugraph/pull/4837 was merged, the `cugraph-docs` repo is the sole source of docs for those projects.

This proposes triggering its builds as part of the nightly pipeline, to keep the docs site up to date with changes to the cuGraph projects.