### PR TITLE
Remove cudf-pandas-integration and add notes on cancellation policy

### DIFF
--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -68,10 +68,6 @@ jobs:
               export BRANCH="${UCX_PY_BRANCH}"
             fi
 
-            if [ "${JUST_REPO}" = "cudf-pandas-integration" ]; then
-              export BRANCH="main"
-            fi
-
             SHA=$(gh api -q '.commit.sha' "repos/${REPO}/branches/${BRANCH}")
             export SHA
 

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -17,6 +17,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.rapids_version }}
   cancel-in-progress: true
 
+# We intentionally allow build jobs to proceed even if their dependencies
+# failed since the upstream failures may be unrelated. This is the reason for
+# the many `if: ${{ !cancelled() }}` conditionals below. This short-circuits
+# the `needs` key, see
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds.
+# See the below links for more information on the decision
+# https://github.com/rapidsai/workflows/pull/11
 jobs:
   get-run-info:
     uses: ./.github/workflows/get-run-info.yaml


### PR DESCRIPTION
This PR removes the cudf-pandas-integration special-casing because [that repo is now archived](https://github.com/rapidsai/cudf-pandas-integration/). Those tests were migrated into cudf proper in https://github.com/rapidsai/cudf/pull/16645.

I have also added some notes on why we allow downstream build jobs to proceed even if upstream ones fail based on https://github.com/rapidsai/workflows/pull/11.