### PR TITLE
Add integration build to nightly workflow

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -661,7 +661,7 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
-  integration-test:
+  integration-build:
     needs:
       - get-run-info
       - cucim-build
@@ -680,6 +680,25 @@ jobs:
       - rmm-build
       - ucx-py-build
       - ucxx-build
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rapidsai/trigger-workflow-and-wait@v1
+        with:
+          owner: rapidsai
+          repo: integration
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_user: GPUtester
+          workflow_file_name: build.yaml
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          wait_interval: 120
+          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.integration) }}
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+  integration-test:
+    needs:
+      - integration-build
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -697,8 +697,9 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   integration-test:
-    needs:
-      - integration-build
+    needs: [integration-build]
+    # we want to always run the integration tests to ascertain that solves
+    # aren't using dated packages. See https://github.com/rapidsai/integration/pull/690.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When a new branch is cut at burndown, we typically wait a few days and then manually trigger an integration build to get all of the nightly packages.

This PR adds the build to the nightly workflows so that we don't have to make this manual effort for every release cycle.
