### PR TITLE
Add raft->ucxx dependency

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -195,7 +195,7 @@ jobs:
           trigger_workflow: true
           wait_workflow: true
   raft-build:
-    needs: [get-run-info, rmm-build, dask-cuda-build]
+    needs: [get-run-info, rmm-build, dask-cuda-build, ucxx-build]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As of https://github.com/rapidsai/raft/pull/1983/, raft-dask depends on ucxx.