### PR TITLE
Remove 25.02

### DIFF
--- a/.github/workflows/nightly-pipeline-trigger.yaml
+++ b/.github/workflows/nightly-pipeline-trigger.yaml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - rapids_version: "25.02"
-            run_tests: false
           - rapids_version: "25.04"
             run_tests: true
     steps:


### PR DESCRIPTION
We can drop `branch-25.02` builds now