### PR TITLE
Remove unneeded `rapids-cmake-build` dependency.

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -658,7 +658,6 @@ jobs:
       - kvikio-build
       - nx-cugraph-build
       - raft-build
-      - rapids-cmake-build
       - rmm-build
       - ucx-py-build
       - ucxx-build
@@ -713,7 +712,6 @@ jobs:
       - kvikio-build
       - nx-cugraph-build
       - raft-build
-      - rapids-cmake-build
       - rmm-build
       - ucx-py-build
       - ucxx-build


### PR DESCRIPTION
Looks like this was missed in https://github.com/rapidsai/workflows/pull/79