### PR TITLE
Drop cuSpatial from nightly builds/tests.

### DIFF
--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -38,7 +38,6 @@ jobs:
         rapidsai/cugraph-gnn
         rapidsai/cuml
         rapidsai/cumlprims_mg
-        rapidsai/cuspatial
         rapidsai/cuvs
         rapidsai/cuxfilter
         rapidsai/dask-cuda
@@ -392,44 +391,8 @@ jobs:
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true
-  cuspatial-build:
-    needs: [get-run-info, rmm-build, cudf-build]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
-        with:
-          owner: rapidsai
-          repo: cuspatial
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: build.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
-  cuspatial-tests:
-    needs: [get-run-info, cuspatial-build]
-    if: ${{ needs.cuspatial-build.result == 'success' && !cancelled() && inputs.run_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rapidsai/trigger-workflow-and-wait@v1
-        with:
-          owner: rapidsai
-          repo: cuspatial
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
-          github_user: GPUtester
-          workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
-          wait_interval: 120
-          client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.cuspatial) }}
-          propagate_failure: true
-          trigger_workflow: true
-          wait_workflow: true
   cuxfilter-build:
-    needs: [get-run-info, cudf-build, cuspatial-build, dask-cuda-build]
+    needs: [get-run-info, cudf-build, dask-cuda-build]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -689,7 +652,6 @@ jobs:
       - cugraph-gnn-build
       - cuml-build
       - cumlprims_mg-build
-      - cuspatial-build
       - cuxfilter-build
       - dask-cuda-build
       - kvikio-build
@@ -743,7 +705,6 @@ jobs:
       - cugraph-gnn-build
       - cuml-build
       - cumlprims_mg-build
-      - cuspatial-build
       - cuxfilter-build
       - dask-cuda-build
       - kvikio-build


### PR DESCRIPTION
cuSpatial will not be published in 25.06: https://docs.rapids.ai/notices/rsn0045/

This PR drops cuSpatial from the nightly builds/tests.

Depends on https://github.com/rapidsai/cuxfilter/pull/681 and https://github.com/rapidsai/integration/pull/757.
