### PR TITLE
Update rmm to use main branch

### DIFF
--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -67,6 +67,9 @@ jobs:
             if [ "${JUST_REPO}" = "ucx-py" ] || [ "${JUST_REPO}" = "ucxx" ]; then
               export BRANCH="${UCX_PY_BRANCH}"
             fi
+            if [ "${JUST_REPO}" = "rmm" ]; then
+              export BRANCH="main"
+            fi
 
             SHA=$(gh api -q '.commit.sha' "repos/${REPO}/branches/${BRANCH}")
             export SHA

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -63,7 +63,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: build.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          ref: main
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: true
@@ -81,7 +81,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: test.yaml
-          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
+          ref: main
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: true


### PR DESCRIPTION
`rmm` is piloting the new branching strategy (https://docs.rapids.ai/notices/rsn0047/). This means its `main` branch should be used for nightly builds and tests.

This PR overrides the refs used just for `rmm` to use the `main` branch instead of `branch-yy.mm`.
