### PR TITLE
Revert "Update rmm to use main branch"

### DIFF
--- a/.github/workflows/get-run-info.yaml
+++ b/.github/workflows/get-run-info.yaml
@@ -67,9 +67,6 @@ jobs:
             if [ "${JUST_REPO}" = "ucx-py" ] || [ "${JUST_REPO}" = "ucxx" ]; then
               export BRANCH="${UCX_PY_BRANCH}"
             fi
-            if [ "${JUST_REPO}" = "rmm" ]; then
-              export BRANCH="main"
-            fi
 
             SHA=$(gh api -q '.commit.sha' "repos/${REPO}/branches/${BRANCH}")
             export SHA

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -63,7 +63,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: build.yaml
-          ref: main
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: true
@@ -81,7 +81,7 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           github_user: GPUtester
           workflow_file_name: test.yaml
-          ref: main
+          ref: ${{ fromJSON(needs.get-run-info.outputs.obj).branch }}
           wait_interval: 120
           client_payload: ${{ toJSON(fromJSON(needs.get-run-info.outputs.obj).payloads.rmm) }}
           propagate_failure: true


### PR DESCRIPTION
Reverts rapidsai/workflows#86 following the teams decision to extend new branching strategy implementation by one release cycle. 

See:
- https://github.com/rapidsai/docs/pull/639/files
- https://github.com/rapidsai/ops/issues/3968#issuecomment-3053016745